### PR TITLE
release: prepare 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-07-14
+
+### Changed
+
+- Release metadata and the English/Chinese installation examples now reference version 1.2.1. No public API changes.
+
 ## [1.2.0] - 2026-07-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,7 +1428,7 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "sensitive-rs"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sensitive-rs"
 description = "A Rust library for sensitive data detection and filtering, supporting Chinese and English text with trie-based algorithms."
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["houseme <housemecn@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-sensitive-rs = "1.2.0"
+sensitive-rs = "1.2.1"
 ```
 
 For environments that should avoid `rayon` (for example WASM or embedded targets), disable default features:
 
 ```toml
 [dependencies]
-sensitive-rs = { version = "1.2.0", default-features = false }
+sensitive-rs = { version = "1.2.1", default-features = false }
 ```
 
 ## Quick Start
@@ -104,7 +104,7 @@ Install with the `cli` feature:
 
 ```toml
 [dependencies]
-sensitive-rs = { version = "1.2.0", features = ["cli"] }
+sensitive-rs = { version = "1.2.1", features = ["cli"] }
 ```
 
 Or install directly:

--- a/README_CN.md
+++ b/README_CN.md
@@ -45,14 +45,14 @@
 
 ```toml
 [dependencies]
-sensitive-rs = "1.2.0"
+sensitive-rs = "1.2.1"
 ```
 
 如果目标环境不适合引入 `rayon`（例如 WASM 或嵌入式场景），可以关闭默认功能：
 
 ```toml
 [dependencies]
-sensitive-rs = { version = "1.2.0", default-features = false }
+sensitive-rs = { version = "1.2.1", default-features = false }
 ```
 
 ## 快速开始
@@ -104,7 +104,7 @@ let stream_results = filter.find_all_streaming(reader)?;
 
 ```toml
 [dependencies]
-sensitive-rs = { version = "1.2.0", features = ["cli"] }
+sensitive-rs = { version = "1.2.1", features = ["cli"] }
 ```
 
 或直接安装：


### PR DESCRIPTION
## Summary

Prepare the 1.2.1 patch release from the current `main` source.

- Bump the crate and lockfile version to 1.2.1.
- Update the English and Chinese dependency examples.
- Add the 1.2.1 changelog entry; there are no public API changes.

## Validation

- `cargo fmt --all --check`
- `cargo check --no-default-features --features cli`
- `cargo test --all-features`
- `cargo check --examples --all-features`
- `git diff --check`
- `cargo package --allow-dirty --no-verify`
